### PR TITLE
Add Python-friendly wrapper DLL

### DIFF
--- a/.github/workflows/build-wrapper.yml
+++ b/.github/workflows/build-wrapper.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         arch: [x64, Win32]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
       - name: Configure

--- a/.github/workflows/build-wrapper.yml
+++ b/.github/workflows/build-wrapper.yml
@@ -1,0 +1,27 @@
+name: Build Wrapper
+
+on:
+  push:
+    paths:
+      - '**'
+  pull_request:
+
+jobs:
+  build:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        arch: [x64, Win32]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: Configure
+        run: cmake -B build -A ${{ matrix.arch }} -DCMAKE_BUILD_TYPE=Release
+      - name: Build
+        run: cmake --build build --config Release --target win-capture-audio-wrapper
+      - name: Upload
+        uses: actions/upload-artifact@v3
+        with:
+          name: win-capture-audio-wrapper-${{ matrix.arch }}
+          path: build/Release/win-capture-audio-wrapper.dll

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,3 +69,13 @@ add_custom_command(TARGET ${CMAKE_PROJECT_NAME} POST_BUILD
 
     VERBATIM
 )
+
+add_library(win-capture-audio-wrapper SHARED
+    src/wrapper.cpp
+    src/audio-capture-helper.cpp
+    src/mixer-wrapper.cpp
+)
+set_property(TARGET win-capture-audio-wrapper PROPERTY CXX_STANDARD 23)
+target_compile_definitions(win-capture-audio-wrapper PRIVATE BUILD_WRAPPER)
+target_include_directories(win-capture-audio-wrapper PUBLIC ${CMAKE_SOURCE_DIR}/deps/wil/include)
+target_link_libraries(win-capture-audio-wrapper dwmapi ksuser mmdevapi)

--- a/src/audio-capture-helper.cpp
+++ b/src/audio-capture-helper.cpp
@@ -11,7 +11,9 @@
 #include <wil/result_macros.h>
 
 #include "audio-capture-helper.hpp"
+#ifndef BUILD_WRAPPER
 #include "format-conversion.hpp"
+#endif
 
 AUDIOCLIENT_ACTIVATION_PARAMS AudioCaptureHelper::GetParams()
 {

--- a/src/common.hpp
+++ b/src/common.hpp
@@ -1,11 +1,24 @@
 #pragma once
 
-#include <util/platform.h>
 #include <windows.h>
 #include <stdio.h>
 #include <stdint.h>
 
+#ifndef BUILD_WRAPPER
+#include <util/platform.h>
 #include <obs.h>
+#else
+#include <stdarg.h>
+
+enum { LOG_DEBUG, LOG_INFO, LOG_WARNING, LOG_ERROR };
+
+inline static void blogva(int level, const char *format, va_list args)
+{
+	(void)level;
+	vfprintf(stderr, format, args);
+	fprintf(stderr, "\n");
+}
+#endif
 
 #define do_log(level, format, ...) \
 	do_log_source(level, "[win-capture-audio] (%s) " format, __func__, ##__VA_ARGS__)

--- a/src/mixer-wrapper.cpp
+++ b/src/mixer-wrapper.cpp
@@ -1,0 +1,26 @@
+#include "mixer.hpp"
+#ifdef BUILD_WRAPPER
+
+Mixer::Mixer(WAVEFORMATEX fmt) : format(fmt) {}
+
+Mixer::~Mixer() {}
+
+void Mixer::SubmitPacket(UINT64, float *data, UINT32 num_frames)
+{
+	auto lock = buffer_section.lock();
+	buffer.insert(buffer.end(), data, data + num_frames * format.nChannels);
+}
+
+size_t Mixer::Read(float *out, size_t frames)
+{
+	auto lock = buffer_section.lock();
+	size_t samples = frames * format.nChannels;
+	size_t available = std::min(samples, buffer.size());
+	for (size_t i = 0; i < available; ++i) {
+		out[i] = buffer.front();
+		buffer.pop_front();
+	}
+	return available / format.nChannels;
+}
+
+#endif

--- a/src/wrapper.cpp
+++ b/src/wrapper.cpp
@@ -1,0 +1,63 @@
+#include "audio-capture-helper.hpp"
+#include "mixer.hpp"
+#include <memory>
+#include <limits.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef void *WCA_Handle;
+
+static WAVEFORMATEX make_format(unsigned int sample_rate, unsigned short channels)
+{
+	WAVEFORMATEX fmt{};
+	fmt.wFormatTag = WAVE_FORMAT_IEEE_FLOAT;
+	fmt.nChannels = channels;
+	fmt.nSamplesPerSec = sample_rate;
+	fmt.nBlockAlign = channels * sizeof(float);
+	fmt.nAvgBytesPerSec = sample_rate * fmt.nBlockAlign;
+	fmt.wBitsPerSample = CHAR_BIT * sizeof(float);
+	fmt.cbSize = 0;
+	return fmt;
+}
+
+struct CaptureInstance {
+	Mixer mixer;
+	std::unique_ptr<AudioCaptureHelper> helper;
+	CaptureInstance(unsigned int pid, unsigned int rate, unsigned short ch)
+		: mixer(make_format(rate, ch)),
+		  helper(std::make_unique<AudioCaptureHelper>(&mixer, mixer.GetFormat(), pid))
+	{
+	}
+};
+
+__declspec(dllexport) WCA_Handle sca_create_capture(unsigned int pid, unsigned int sample_rate,
+						    unsigned short channels)
+{
+	try {
+		auto inst = new CaptureInstance(pid, sample_rate, channels);
+		return inst;
+	} catch (...) {
+		return nullptr;
+	}
+}
+
+__declspec(dllexport) unsigned int sca_read_audio_frames(WCA_Handle h, float *buffer,
+							 unsigned int frames)
+{
+	if (!h || !buffer)
+		return 0;
+	auto inst = static_cast<CaptureInstance *>(h);
+	return static_cast<unsigned int>(inst->mixer.Read(buffer, frames));
+}
+
+__declspec(dllexport) void sca_destroy_capture(WCA_Handle h)
+{
+	auto inst = static_cast<CaptureInstance *>(h);
+	delete inst;
+}
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
## Summary
- add wrapper DLL target exposing simple C API
- make logging independent of OBS when building wrapper
- implement lightweight mixer for the wrapper
- provide GitHub workflow to build 32-bit and 64-bit wrapper DLLs

## Testing
- `cmake --version | head -n 1`


------
https://chatgpt.com/codex/tasks/task_e_686be9c9988c8331ab56f822688e76bf