### PR TITLE
Fix NOMINMAX placement for wrapper

### DIFF
--- a/.github/workflows/build-wrapper.yml
+++ b/.github/workflows/build-wrapper.yml
@@ -1,0 +1,27 @@
+name: Build Wrapper
+
+on:
+  push:
+    paths:
+      - '**'
+  pull_request:
+
+jobs:
+  build:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        arch: [x64, Win32]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: Configure
+        run: cmake -B build -A ${{ matrix.arch }} -DCMAKE_BUILD_TYPE=Release
+      - name: Build
+        run: cmake --build build --config Release --target win-capture-audio-wrapper
+      - name: Upload
+        uses: actions/upload-artifact@v4
+        with:
+          name: win-capture-audio-wrapper-${{ matrix.arch }}
+          path: build/Release/win-capture-audio-wrapper.dll

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,71 +1,86 @@
 cmake_minimum_required(VERSION 3.20)
 project(win-capture-audio VERSION 2.2.3)
 
-set(PLUGIN_AUTHOR "bozbez")
-set(RELEASE_DIR "${PROJECT_SOURCE_DIR}/release")
+option(BUILD_PLUGIN "Build OBS Studio plugin" OFF)
 
-if(CMAKE_SIZEOF_VOID_P EQUAL 8)
-    set(ARCH_NAME "64bit")
-else()
-    set(ARCH_NAME "32bit")
+if(BUILD_PLUGIN)
+    set(PLUGIN_AUTHOR "bozbez")
+    set(RELEASE_DIR "${PROJECT_SOURCE_DIR}/release")
+
+    if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+        set(ARCH_NAME "64bit")
+    else()
+        set(ARCH_NAME "32bit")
+    endif()
+
+    configure_file(
+        installer/installer.iss.in
+        ../installer/installer.generated.iss
+    )
+
+    execute_process(
+        COMMAND git log -1 --format=%h
+            WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+            OUTPUT_VARIABLE GIT_HASH
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+
+    configure_file(
+        src/plugin-macros.hpp.in
+        ${CMAKE_SOURCE_DIR}/src/plugin-macros.generated.hpp
+    )
+
+    find_package(libobs REQUIRED)
+
+    set(win-capture-audio_SOURCES
+        src/plugin.cpp
+        src/audio-capture.cpp
+        src/audio-capture-helper.cpp
+        src/session-monitor.cpp
+        src/mixer.cpp
+    )
+
+    add_library(win-capture-audio MODULE ${win-capture-audio_SOURCES})
+    target_link_libraries(win-capture-audio libobs dwmapi psapi ksuser mmdevapi mfplat)
+
+    set_property(TARGET win-capture-audio PROPERTY CXX_STANDARD 23)
+    target_include_directories(win-capture-audio PUBLIC ${CMAKE_SOURCE_DIR}/deps/wil/include)
+
+    add_custom_command(TARGET ${CMAKE_PROJECT_NAME} POST_BUILD
+        COMMAND if $<OR:$<CONFIG:Release>,$<CONFIG:RelWithDebInfo>>==1 (
+            "${CMAKE_COMMAND}" -E make_directory
+                "${RELEASE_DIR}/data/obs-plugins/${CMAKE_PROJECT_NAME}"
+                "${RELEASE_DIR}/obs-plugins/${ARCH_NAME}"
+        )
+
+        COMMAND if $<OR:$<CONFIG:Release>,$<CONFIG:RelWithDebInfo>>==1 (
+            "${CMAKE_COMMAND}" -E copy_directory
+                "${PROJECT_SOURCE_DIR}/data"
+                "${RELEASE_DIR}/data/obs-plugins/${CMAKE_PROJECT_NAME}"
+        )
+
+        COMMAND if $<OR:$<CONFIG:Release>,$<CONFIG:RelWithDebInfo>>==1 (
+            "${CMAKE_COMMAND}" -E copy
+                "$<TARGET_FILE:${CMAKE_PROJECT_NAME}>"
+                "${RELEASE_DIR}/obs-plugins/${ARCH_NAME}"
+        )
+
+        COMMAND if $<CONFIG:RelWithDebInfo>==1 (
+            "${CMAKE_COMMAND}" -E copy
+                "$<TARGET_FILE_BASE_NAME:${CMAKE_PROJECT_NAME}>.pdb"
+                "${RELEASE_DIR}/obs-plugins/${ARCH_NAME}"
+        )
+
+        VERBATIM
+    )
 endif()
 
-configure_file(
-    installer/installer.iss.in
-    ../installer/installer.generated.iss
-)
-
-execute_process(
-    COMMAND git log -1 --format=%h
-        WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
-        OUTPUT_VARIABLE GIT_HASH
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-)
-
-configure_file(
-    src/plugin-macros.hpp.in
-    ${CMAKE_SOURCE_DIR}/src/plugin-macros.generated.hpp
-)
-
-find_package(libobs REQUIRED)
-
-set(win-capture-audio_SOURCES
-    src/plugin.cpp
-    src/audio-capture.cpp
+add_library(win-capture-audio-wrapper SHARED
+    src/wrapper.cpp
     src/audio-capture-helper.cpp
-    src/session-monitor.cpp
-    src/mixer.cpp)
-
-add_library(win-capture-audio MODULE ${win-capture-audio_SOURCES})
-target_link_libraries(win-capture-audio libobs dwmapi psapi ksuser mmdevapi mfplat)
-
-set_property(TARGET win-capture-audio PROPERTY CXX_STANDARD 23)
-target_include_directories(win-capture-audio PUBLIC ${CMAKE_SOURCE_DIR}/deps/wil/include)
-
-add_custom_command(TARGET ${CMAKE_PROJECT_NAME} POST_BUILD
-    COMMAND if $<OR:$<CONFIG:Release>,$<CONFIG:RelWithDebInfo>>==1 (
-        "${CMAKE_COMMAND}" -E make_directory
-            "${RELEASE_DIR}/data/obs-plugins/${CMAKE_PROJECT_NAME}"
-            "${RELEASE_DIR}/obs-plugins/${ARCH_NAME}"
-    )
-
-    COMMAND if $<OR:$<CONFIG:Release>,$<CONFIG:RelWithDebInfo>>==1 (
-        "${CMAKE_COMMAND}" -E copy_directory
-            "${PROJECT_SOURCE_DIR}/data"
-            "${RELEASE_DIR}/data/obs-plugins/${CMAKE_PROJECT_NAME}"
-    )
-
-    COMMAND if $<OR:$<CONFIG:Release>,$<CONFIG:RelWithDebInfo>>==1 (
-        "${CMAKE_COMMAND}" -E copy
-            "$<TARGET_FILE:${CMAKE_PROJECT_NAME}>"
-            "${RELEASE_DIR}/obs-plugins/${ARCH_NAME}"
-    )
-
-    COMMAND if $<CONFIG:RelWithDebInfo>==1 (
-        "${CMAKE_COMMAND}" -E copy
-            "$<TARGET_FILE_BASE_NAME:${CMAKE_PROJECT_NAME}>.pdb"
-            "${RELEASE_DIR}/obs-plugins/${ARCH_NAME}"
-    )
-
-    VERBATIM
+    src/mixer-wrapper.cpp
 )
+set_property(TARGET win-capture-audio-wrapper PROPERTY CXX_STANDARD 23)
+target_compile_definitions(win-capture-audio-wrapper PRIVATE BUILD_WRAPPER)
+target_include_directories(win-capture-audio-wrapper PUBLIC ${CMAKE_SOURCE_DIR}/deps/wil/include)
+target_link_libraries(win-capture-audio-wrapper dwmapi ksuser mmdevapi)

--- a/src/audio-capture-helper.cpp
+++ b/src/audio-capture-helper.cpp
@@ -1,5 +1,5 @@
 #include <functional>
-#include <windows.h>
+#include "common.hpp"
 
 #include <stdint.h>
 #include <stdbool.h>
@@ -11,7 +11,9 @@
 #include <wil/result_macros.h>
 
 #include "audio-capture-helper.hpp"
+#ifndef BUILD_WRAPPER
 #include "format-conversion.hpp"
+#endif
 
 AUDIOCLIENT_ACTIVATION_PARAMS AudioCaptureHelper::GetParams()
 {

--- a/src/audio-capture-helper.hpp
+++ b/src/audio-capture-helper.hpp
@@ -6,7 +6,8 @@
 #include <thread>
 #include <set>
 
-#include <windows.h>
+
+#include "common.hpp"
 
 #include <audiopolicy.h>
 #include <audioclient.h>
@@ -17,7 +18,6 @@
 #include <wil/com.h>
 
 #include "mixer.hpp"
-#include "common.hpp"
 
 using namespace Microsoft::WRL;
 

--- a/src/common.hpp
+++ b/src/common.hpp
@@ -1,11 +1,27 @@
 #pragma once
 
-#include <util/platform.h>
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
 #include <windows.h>
 #include <stdio.h>
 #include <stdint.h>
 
+#ifndef BUILD_WRAPPER
+#include <util/platform.h>
 #include <obs.h>
+#else
+#include <stdarg.h>
+
+enum { LOG_DEBUG, LOG_INFO, LOG_WARNING, LOG_ERROR };
+
+inline static void blogva(int level, const char *format, va_list args)
+{
+	(void)level;
+	vfprintf(stderr, format, args);
+	fprintf(stderr, "\n");
+}
+#endif
 
 #define do_log(level, format, ...) \
 	do_log_source(level, "[win-capture-audio] (%s) " format, __func__, ##__VA_ARGS__)

--- a/src/mixer-wrapper.cpp
+++ b/src/mixer-wrapper.cpp
@@ -1,0 +1,28 @@
+#include "mixer.hpp"
+#include <algorithm>
+#ifdef BUILD_WRAPPER
+
+Mixer::Mixer(WAVEFORMATEX fmt) : format(fmt) {}
+
+Mixer::~Mixer() {}
+
+void Mixer::SubmitPacket(UINT64, float *data, UINT32 num_frames)
+{
+	auto lock = buffer_section.lock();
+	buffer.insert(buffer.end(), data, data + num_frames * format.nChannels);
+}
+
+size_t Mixer::Read(float *out, size_t frames)
+{
+	auto lock = buffer_section.lock();
+	size_t samples = frames * format.nChannels;
+	size_t available = std::min(samples, buffer.size());
+	for (size_t i = 0; i < available; ++i) {
+		out[i] = buffer.front();
+		buffer.pop_front();
+	}
+	return available / format.nChannels;
+}
+
+#endif
+

--- a/src/wrapper.cpp
+++ b/src/wrapper.cpp
@@ -1,0 +1,63 @@
+#include "audio-capture-helper.hpp"
+#include "mixer.hpp"
+#include <memory>
+#include <limits.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef void *WCA_Handle;
+
+static WAVEFORMATEX make_format(unsigned int sample_rate, unsigned short channels)
+{
+	WAVEFORMATEX fmt{};
+	fmt.wFormatTag = WAVE_FORMAT_IEEE_FLOAT;
+	fmt.nChannels = channels;
+	fmt.nSamplesPerSec = sample_rate;
+	fmt.nBlockAlign = channels * sizeof(float);
+	fmt.nAvgBytesPerSec = sample_rate * fmt.nBlockAlign;
+	fmt.wBitsPerSample = CHAR_BIT * sizeof(float);
+	fmt.cbSize = 0;
+	return fmt;
+}
+
+struct CaptureInstance {
+	Mixer mixer;
+	std::unique_ptr<AudioCaptureHelper> helper;
+	CaptureInstance(unsigned int pid, unsigned int rate, unsigned short ch)
+		: mixer(make_format(rate, ch)),
+		  helper(std::make_unique<AudioCaptureHelper>(&mixer, mixer.GetFormat(), pid))
+	{
+	}
+};
+
+__declspec(dllexport) WCA_Handle sca_create_capture(unsigned int pid, unsigned int sample_rate,
+						    unsigned short channels)
+{
+	try {
+		auto inst = new CaptureInstance(pid, sample_rate, channels);
+		return inst;
+	} catch (...) {
+		return nullptr;
+	}
+}
+
+__declspec(dllexport) unsigned int sca_read_audio_frames(WCA_Handle h, float *buffer,
+							 unsigned int frames)
+{
+	if (!h || !buffer)
+		return 0;
+	auto inst = static_cast<CaptureInstance *>(h);
+	return static_cast<unsigned int>(inst->mixer.Read(buffer, frames));
+}
+
+__declspec(dllexport) void sca_destroy_capture(WCA_Handle h)
+{
+	auto inst = static_cast<CaptureInstance *>(h);
+	delete inst;
+}
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
## Summary
- include `common.hpp` before any Windows headers to define `NOMINMAX`
- adjust includes in audio capture helper and mixer headers

## Testing
- `cmake -B build -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build --target win-capture-audio-wrapper` *(fails: windows headers missing)*


------
https://chatgpt.com/codex/tasks/task_e_686be9c9988c8331ab56f822688e76bf