### PR TITLE
Add Python wrapper docstring and update README

### DIFF
--- a/.github/workflows/build-wrapper.yml
+++ b/.github/workflows/build-wrapper.yml
@@ -1,0 +1,27 @@
+name: Build Wrapper
+
+on:
+  push:
+    paths:
+      - '**'
+  pull_request:
+
+jobs:
+  build:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        arch: [x64, Win32]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - name: Configure
+        run: cmake -B build -A ${{ matrix.arch }} -DCMAKE_BUILD_TYPE=Release
+      - name: Build
+        run: cmake --build build --config Release --target win-capture-audio-wrapper
+      - name: Upload
+        uses: actions/upload-artifact@v4
+        with:
+          name: win-capture-audio-wrapper-${{ matrix.arch }}
+          path: build/Release/win-capture-audio-wrapper.dll

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,71 +1,86 @@
 cmake_minimum_required(VERSION 3.20)
 project(win-capture-audio VERSION 2.2.3)
 
-set(PLUGIN_AUTHOR "bozbez")
-set(RELEASE_DIR "${PROJECT_SOURCE_DIR}/release")
+option(BUILD_PLUGIN "Build OBS Studio plugin" OFF)
 
-if(CMAKE_SIZEOF_VOID_P EQUAL 8)
-    set(ARCH_NAME "64bit")
-else()
-    set(ARCH_NAME "32bit")
+if(BUILD_PLUGIN)
+    set(PLUGIN_AUTHOR "bozbez")
+    set(RELEASE_DIR "${PROJECT_SOURCE_DIR}/release")
+
+    if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+        set(ARCH_NAME "64bit")
+    else()
+        set(ARCH_NAME "32bit")
+    endif()
+
+    configure_file(
+        installer/installer.iss.in
+        ../installer/installer.generated.iss
+    )
+
+    execute_process(
+        COMMAND git log -1 --format=%h
+            WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+            OUTPUT_VARIABLE GIT_HASH
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+
+    configure_file(
+        src/plugin-macros.hpp.in
+        ${CMAKE_SOURCE_DIR}/src/plugin-macros.generated.hpp
+    )
+
+    find_package(libobs REQUIRED)
+
+    set(win-capture-audio_SOURCES
+        src/plugin.cpp
+        src/audio-capture.cpp
+        src/audio-capture-helper.cpp
+        src/session-monitor.cpp
+        src/mixer.cpp
+    )
+
+    add_library(win-capture-audio MODULE ${win-capture-audio_SOURCES})
+    target_link_libraries(win-capture-audio libobs dwmapi psapi ksuser mmdevapi mfplat)
+
+    set_property(TARGET win-capture-audio PROPERTY CXX_STANDARD 23)
+    target_include_directories(win-capture-audio PUBLIC ${CMAKE_SOURCE_DIR}/deps/wil/include)
+
+    add_custom_command(TARGET ${CMAKE_PROJECT_NAME} POST_BUILD
+        COMMAND if $<OR:$<CONFIG:Release>,$<CONFIG:RelWithDebInfo>>==1 (
+            "${CMAKE_COMMAND}" -E make_directory
+                "${RELEASE_DIR}/data/obs-plugins/${CMAKE_PROJECT_NAME}"
+                "${RELEASE_DIR}/obs-plugins/${ARCH_NAME}"
+        )
+
+        COMMAND if $<OR:$<CONFIG:Release>,$<CONFIG:RelWithDebInfo>>==1 (
+            "${CMAKE_COMMAND}" -E copy_directory
+                "${PROJECT_SOURCE_DIR}/data"
+                "${RELEASE_DIR}/data/obs-plugins/${CMAKE_PROJECT_NAME}"
+        )
+
+        COMMAND if $<OR:$<CONFIG:Release>,$<CONFIG:RelWithDebInfo>>==1 (
+            "${CMAKE_COMMAND}" -E copy
+                "$<TARGET_FILE:${CMAKE_PROJECT_NAME}>"
+                "${RELEASE_DIR}/obs-plugins/${ARCH_NAME}"
+        )
+
+        COMMAND if $<CONFIG:RelWithDebInfo>==1 (
+            "${CMAKE_COMMAND}" -E copy
+                "$<TARGET_FILE_BASE_NAME:${CMAKE_PROJECT_NAME}>.pdb"
+                "${RELEASE_DIR}/obs-plugins/${ARCH_NAME}"
+        )
+
+        VERBATIM
+    )
 endif()
 
-configure_file(
-    installer/installer.iss.in
-    ../installer/installer.generated.iss
-)
-
-execute_process(
-    COMMAND git log -1 --format=%h
-        WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
-        OUTPUT_VARIABLE GIT_HASH
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-)
-
-configure_file(
-    src/plugin-macros.hpp.in
-    ${CMAKE_SOURCE_DIR}/src/plugin-macros.generated.hpp
-)
-
-find_package(libobs REQUIRED)
-
-set(win-capture-audio_SOURCES
-    src/plugin.cpp
-    src/audio-capture.cpp
+add_library(win-capture-audio-wrapper SHARED
+    src/wrapper.cpp
     src/audio-capture-helper.cpp
-    src/session-monitor.cpp
-    src/mixer.cpp)
-
-add_library(win-capture-audio MODULE ${win-capture-audio_SOURCES})
-target_link_libraries(win-capture-audio libobs dwmapi psapi ksuser mmdevapi mfplat)
-
-set_property(TARGET win-capture-audio PROPERTY CXX_STANDARD 23)
-target_include_directories(win-capture-audio PUBLIC ${CMAKE_SOURCE_DIR}/deps/wil/include)
-
-add_custom_command(TARGET ${CMAKE_PROJECT_NAME} POST_BUILD
-    COMMAND if $<OR:$<CONFIG:Release>,$<CONFIG:RelWithDebInfo>>==1 (
-        "${CMAKE_COMMAND}" -E make_directory
-            "${RELEASE_DIR}/data/obs-plugins/${CMAKE_PROJECT_NAME}"
-            "${RELEASE_DIR}/obs-plugins/${ARCH_NAME}"
-    )
-
-    COMMAND if $<OR:$<CONFIG:Release>,$<CONFIG:RelWithDebInfo>>==1 (
-        "${CMAKE_COMMAND}" -E copy_directory
-            "${PROJECT_SOURCE_DIR}/data"
-            "${RELEASE_DIR}/data/obs-plugins/${CMAKE_PROJECT_NAME}"
-    )
-
-    COMMAND if $<OR:$<CONFIG:Release>,$<CONFIG:RelWithDebInfo>>==1 (
-        "${CMAKE_COMMAND}" -E copy
-            "$<TARGET_FILE:${CMAKE_PROJECT_NAME}>"
-            "${RELEASE_DIR}/obs-plugins/${ARCH_NAME}"
-    )
-
-    COMMAND if $<CONFIG:RelWithDebInfo>==1 (
-        "${CMAKE_COMMAND}" -E copy
-            "$<TARGET_FILE_BASE_NAME:${CMAKE_PROJECT_NAME}>.pdb"
-            "${RELEASE_DIR}/obs-plugins/${ARCH_NAME}"
-    )
-
-    VERBATIM
+    src/mixer-wrapper.cpp
 )
+set_property(TARGET win-capture-audio-wrapper PROPERTY CXX_STANDARD 23)
+target_compile_definitions(win-capture-audio-wrapper PRIVATE BUILD_WRAPPER)
+target_include_directories(win-capture-audio-wrapper PUBLIC ${CMAKE_SOURCE_DIR}/deps/wil/include)
+target_link_libraries(win-capture-audio-wrapper dwmapi ksuser mmdevapi)

--- a/README.md
+++ b/README.md
@@ -1,24 +1,44 @@
-# win-capture-audio
+# win-capture-audio-dll
 
-An OBS plugin similar to OBS's win-capture/game-capture that allows for audio capture from a specific application, rather than the system's audio as a whole. This eliminates the need for third-party software or hardware audio mixing tools that introduce complexity, and in the case of software tools, introduce mandatory latency.
+这是一个基于 [win-capture-audio](https://github.com/bozbez/win-capture-audio) 项目提取出的 DLL 接口，可用于从指定进程捕获音频流，适用于需要在 Python 中采集特定应用程序音频的场景。
 
-Internally it uses [ActivateAudioInterfaceAsync](https://docs.microsoft.com/en-us/windows/win32/api/mmdeviceapi/nf-mmdeviceapi-activateaudiointerfaceasync) with [AUDIOCLIENT_PROCESS_LOOPBACK_PARAMS](https://docs.microsoft.com/en-us/windows/win32/api/audioclientactivationparams/ns-audioclientactivationparams-audioclient_process_loopback_params). This initialization structure is only officially available on Windows 11, however it appears to work additionally on relatively recent versions of Windows 10.
+其底层基于 Windows 的 [ActivateAudioInterfaceAsync](https://docs.microsoft.com/en-us/windows/win32/api/mmdeviceapi/nf-mmdeviceapi-activateaudiointerfaceasync) API，结合 [AUDIOCLIENT_PROCESS_LOOPBACK_PARAMS](https://docs.microsoft.com/en-us/windows/win32/api/audioclientactivationparams/ns-audioclientactivationparams-audioclient_process_loopback_params) 结构实现，能够直接捕获某一进程的输出音频，而不是系统整体输出。
 
-**This plugin is in a BETA state, expect issues - [https://discord.gg/4D5Yk5gFnM](https://discord.gg/4D5Yk5gFnM) for support and updates.**<br/>
-**An updated version of Windows 10 2004 (released 2020-05-27) or later is required.**
+> ⚠️ 注意：该功能官方仅在 Windows 11 支持，但经测在部分更新后的 Windows 10（如 2004 及以上）中也可以正常使用。
 
-**Want to support the development of the plugin? [https://ko-fi.com/bozbez](https://ko-fi.com/bozbez)**
+## 环境要求
 
-![overview](https://raw.githubusercontent.com/bozbez/win-capture-audio/main/media/overview.png)
+- Windows 10 2004（2020 年 5 月）及以上版本（推荐 Windows 11）
+- 已编译的 `win-capture-audio-wrapper.dll`
 
-## Installation and Usage
+## 功能特点
 
-1. Head over to the [Releases](https://github.com/bozbez/win-capture-audio/releases) page and download the latest installer (or zip if you are using a portable installation)
-2. Run the setup wizard, selecting your root OBS folder (`obs-studio/`, _not_ `obs-studio/obs-plugins/`) when asked (or extract the zip to the portable OBS root directory)
-3. Launch OBS and check out the newly available "Application Audio Output Capture" source
+- 低延迟：不依赖 WASAPI Loopback 或虚拟声卡，直接内部环回目标进程音频
+- 精准：仅采集指定进程，不影响系统或其他应用
+- 可嵌入：适合集成进 Python 应用或 AI 音频分析工具链
 
-## Troubleshooting
+## 获取 DLL
 
-- **Application Audio Output Capture source not showing up after install:** this means that either your OBS is out-of-date (check that it is at least 27.1.x) or you have installed the plugin to the wrong location. To re-install, first uninstall via "Add or remove programs" in the Windows settings, and then run the installer again. Make sure to select the top-level `obs-studio/` folder in (probably) `C:/Program Files/`.
+前往 [Releases](../../releases) 页面可以获取最新的 `win-capture-audio-wrapper.dll`，与 `samples` 目录中的脚本放在同一位置后即可被 `wca.py` 自动加载。
+GitHub Actions 会同时构建适用于 32 位和 64 位系统的 DLL，可从 Releases 页面下载。
 
-- **Application Audio Output Capture source not picking up any audio:** this happens when your Windows is too old and does not have support for the API. Note that even if you have a more recent major version such as `20H2` you will still need the latest updates for the plugin to work. If you are on a very old version you might need more than one update for this to work, and the second update might not show up for a few days after the first update.
+## Python Usage
+
+The repository also builds a lightweight DLL that exposes a minimal C API. The helper module [`samples/wca.py`](samples/wca.py) wraps this DLL with an easy to use interface. It can resolve a process by name and stream audio chunks for real-time processing.
+
+```python
+from samples.wca import Capture, record_to_wav
+
+# Save five seconds of audio from the given PID
+record_to_wav(pid=1234, seconds=5, filename="capture.wav")
+
+# Or capture by executable name
+record_to_wav(name="chrome.exe", seconds=5, filename="chrome.wav")
+
+# Or use the class directly
+with Capture(name="notepad.exe") as cap:
+    for chunk in cap.stream():
+        process(chunk)  # do something with audio data
+```
+
+See [`samples/wca.py`](samples/wca.py) for the implementation and additional usage details.

--- a/samples/python_capture.py
+++ b/samples/python_capture.py
@@ -1,0 +1,25 @@
+"""Example script using the simple Python wrapper."""
+
+from wca import record_to_wav
+
+
+def main():
+    import sys
+    if len(sys.argv) < 2:
+        print('Usage: python python_capture.py <pid|process.exe>')
+        return
+
+    target = sys.argv[1]
+    try:
+        pid = int(target)
+        name = None
+    except ValueError:
+        pid = None
+        name = target
+
+    record_to_wav(pid=pid, name=name, seconds=5, filename='capture.wav')
+    print('Wrote capture.wav')
+
+
+if __name__ == '__main__':
+    main()

--- a/samples/wca.py
+++ b/samples/wca.py
@@ -1,0 +1,147 @@
+"""Thin Python wrapper for win-capture-audio-wrapper.dll"""
+import ctypes
+from ctypes import wintypes
+import os
+import wave
+import struct
+import time
+
+_kernel32 = ctypes.WinDLL('kernel32', use_last_error=True)
+
+TH32CS_SNAPPROCESS = 0x00000002
+
+class PROCESSENTRY32(ctypes.Structure):
+    _fields_ = [
+        ('dwSize', wintypes.DWORD),
+        ('cntUsage', wintypes.DWORD),
+        ('th32ProcessID', wintypes.DWORD),
+        ('th32DefaultHeapID', ctypes.POINTER(ctypes.c_ulong)),
+        ('th32ModuleID', wintypes.DWORD),
+        ('cntThreads', wintypes.DWORD),
+        ('th32ParentProcessID', wintypes.DWORD),
+        ('pcPriClassBase', ctypes.c_long),
+        ('dwFlags', wintypes.DWORD),
+        ('szExeFile', wintypes.WCHAR * wintypes.MAX_PATH),
+    ]
+
+_kernel32.CreateToolhelp32Snapshot.argtypes = [wintypes.DWORD, wintypes.DWORD]
+_kernel32.CreateToolhelp32Snapshot.restype = wintypes.HANDLE
+_kernel32.Process32FirstW.argtypes = [wintypes.HANDLE, ctypes.POINTER(PROCESSENTRY32)]
+_kernel32.Process32FirstW.restype = wintypes.BOOL
+_kernel32.Process32NextW.argtypes = [wintypes.HANDLE, ctypes.POINTER(PROCESSENTRY32)]
+_kernel32.Process32NextW.restype = wintypes.BOOL
+_kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+_kernel32.CloseHandle.restype = wintypes.BOOL
+
+
+def _find_pid_by_name(name):
+    snapshot = _kernel32.CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0)
+    entry = PROCESSENTRY32()
+    entry.dwSize = ctypes.sizeof(PROCESSENTRY32)
+    pid = None
+    if _kernel32.Process32FirstW(snapshot, ctypes.byref(entry)):
+        while True:
+            if entry.szExeFile.lower() == name.lower():
+                pid = entry.th32ProcessID
+                break
+            if not _kernel32.Process32NextW(snapshot, ctypes.byref(entry)):
+                break
+    _kernel32.CloseHandle(snapshot)
+    return pid
+
+
+_DLL = None
+
+
+def _load_dll(path=None):
+    global _DLL
+    if _DLL is None:
+        if path is None:
+            path = os.path.join(os.path.dirname(__file__), 'win-capture-audio-wrapper.dll')
+        _DLL = ctypes.WinDLL(path)
+        _DLL.sca_create_capture.argtypes = [wintypes.DWORD, wintypes.UINT, wintypes.USHORT]
+        _DLL.sca_create_capture.restype = ctypes.c_void_p
+        _DLL.sca_read_audio_frames.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_float), wintypes.UINT]
+        _DLL.sca_read_audio_frames.restype = wintypes.UINT
+        _DLL.sca_destroy_capture.argtypes = [ctypes.c_void_p]
+        _DLL.sca_destroy_capture.restype = None
+    return _DLL
+
+
+class Capture:
+    """Capture audio from a specific process."""
+
+    def __init__(self, pid=None, name=None, sample_rate=48000, channels=2, dll_path=None):
+        if pid is None:
+            if name is None:
+                raise ValueError('pid or name required')
+            pid = _find_pid_by_name(name)
+            if pid is None:
+                raise RuntimeError(f'process {name} not found')
+        self._dll = _load_dll(dll_path)
+        self.handle = self._dll.sca_create_capture(pid, sample_rate, channels)
+        if not self.handle:
+            raise RuntimeError('failed to create capture helper')
+        self.rate = sample_rate
+        self.channels = channels
+
+    def read(self, frames):
+        buf = (ctypes.c_float * (frames * self.channels))()
+        got = self._dll.sca_read_audio_frames(self.handle, buf, frames)
+        return list(buf[:got * self.channels])
+
+    def stream(self, frames_per_buffer=1024):
+        """Yield chunks of audio in real time."""
+        while self.handle:
+            data = self.read(frames_per_buffer)
+            if data:
+                yield data
+            else:
+                time.sleep(frames_per_buffer / self.rate)
+
+    def close(self):
+        if self.handle:
+            self._dll.sca_destroy_capture(self.handle)
+            self.handle = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.close()
+
+
+def record_to_wav(pid=None, name=None, seconds=5, filename='capture.wav', sample_rate=48000, channels=2, dll_path=None):
+    """Record audio from the given process and write it to a WAV file."""
+    frames = sample_rate * seconds
+    with Capture(pid=pid, name=name, sample_rate=sample_rate, channels=channels, dll_path=dll_path) as cap:
+        data = []
+        remaining = frames
+        while remaining > 0:
+            chunk = cap.read(min(1024, remaining))
+            if not chunk:
+                break
+            data.extend(chunk)
+            remaining -= len(chunk) // channels
+        with wave.open(filename, "wb") as wf:
+            wf.setnchannels(channels)
+            wf.setsampwidth(4)
+            wf.setframerate(sample_rate)
+            wf.writeframes(b''.join(struct.pack('<f', s) for s in data))
+
+if __name__ == '__main__':
+    import sys
+    if len(sys.argv) < 3:
+        print('Usage: python wca.py <pid|process.exe> <seconds> [output.wav]')
+        sys.exit(1)
+    target = sys.argv[1]
+    try:
+        pid = int(target)
+        name = None
+    except ValueError:
+        pid = None
+        name = target
+    seconds = int(sys.argv[2])
+    out = sys.argv[3] if len(sys.argv) > 3 else 'capture.wav'
+    record_to_wav(pid=pid, name=name, seconds=seconds, filename=out)
+    print('Wrote', out)

--- a/src/audio-capture-helper.hpp
+++ b/src/audio-capture-helper.hpp
@@ -6,7 +6,8 @@
 #include <thread>
 #include <set>
 
-#include <windows.h>
+
+#include "common.hpp"
 
 #include <audiopolicy.h>
 #include <audioclient.h>
@@ -17,7 +18,6 @@
 #include <wil/com.h>
 
 #include "mixer.hpp"
-#include "common.hpp"
 
 using namespace Microsoft::WRL;
 

--- a/src/common.hpp
+++ b/src/common.hpp
@@ -1,11 +1,27 @@
 #pragma once
 
-#include <util/platform.h>
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
 #include <windows.h>
 #include <stdio.h>
 #include <stdint.h>
 
+#ifndef BUILD_WRAPPER
+#include <util/platform.h>
 #include <obs.h>
+#else
+#include <stdarg.h>
+
+enum { LOG_DEBUG, LOG_INFO, LOG_WARNING, LOG_ERROR };
+
+inline static void blogva(int level, const char *format, va_list args)
+{
+	(void)level;
+	vfprintf(stderr, format, args);
+	fprintf(stderr, "\n");
+}
+#endif
 
 #define do_log(level, format, ...) \
 	do_log_source(level, "[win-capture-audio] (%s) " format, __func__, ##__VA_ARGS__)

--- a/src/mixer-wrapper.cpp
+++ b/src/mixer-wrapper.cpp
@@ -1,0 +1,28 @@
+#include "mixer.hpp"
+#include <algorithm>
+#ifdef BUILD_WRAPPER
+
+Mixer::Mixer(WAVEFORMATEX fmt) : format(fmt) {}
+
+Mixer::~Mixer() {}
+
+void Mixer::SubmitPacket(UINT64, float *data, UINT32 num_frames)
+{
+	auto lock = buffer_section.lock();
+	buffer.insert(buffer.end(), data, data + num_frames * format.nChannels);
+}
+
+size_t Mixer::Read(float *out, size_t frames)
+{
+	auto lock = buffer_section.lock();
+	size_t samples = frames * format.nChannels;
+	size_t available = std::min(samples, buffer.size());
+	for (size_t i = 0; i < available; ++i) {
+		out[i] = buffer.front();
+		buffer.pop_front();
+	}
+	return available / format.nChannels;
+}
+
+#endif
+

--- a/src/wrapper.cpp
+++ b/src/wrapper.cpp
@@ -1,0 +1,63 @@
+#include "audio-capture-helper.hpp"
+#include "mixer.hpp"
+#include <memory>
+#include <limits.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef void *WCA_Handle;
+
+static WAVEFORMATEX make_format(unsigned int sample_rate, unsigned short channels)
+{
+	WAVEFORMATEX fmt{};
+	fmt.wFormatTag = WAVE_FORMAT_IEEE_FLOAT;
+	fmt.nChannels = channels;
+	fmt.nSamplesPerSec = sample_rate;
+	fmt.nBlockAlign = channels * sizeof(float);
+	fmt.nAvgBytesPerSec = sample_rate * fmt.nBlockAlign;
+	fmt.wBitsPerSample = CHAR_BIT * sizeof(float);
+	fmt.cbSize = 0;
+	return fmt;
+}
+
+struct CaptureInstance {
+	Mixer mixer;
+	std::unique_ptr<AudioCaptureHelper> helper;
+	CaptureInstance(unsigned int pid, unsigned int rate, unsigned short ch)
+		: mixer(make_format(rate, ch)),
+		  helper(std::make_unique<AudioCaptureHelper>(&mixer, mixer.GetFormat(), pid))
+	{
+	}
+};
+
+__declspec(dllexport) WCA_Handle sca_create_capture(unsigned int pid, unsigned int sample_rate,
+						    unsigned short channels)
+{
+	try {
+		auto inst = new CaptureInstance(pid, sample_rate, channels);
+		return inst;
+	} catch (...) {
+		return nullptr;
+	}
+}
+
+__declspec(dllexport) unsigned int sca_read_audio_frames(WCA_Handle h, float *buffer,
+							 unsigned int frames)
+{
+	if (!h || !buffer)
+		return 0;
+	auto inst = static_cast<CaptureInstance *>(h);
+	return static_cast<unsigned int>(inst->mixer.Read(buffer, frames));
+}
+
+__declspec(dllexport) void sca_destroy_capture(WCA_Handle h)
+{
+	auto inst = static_cast<CaptureInstance *>(h);
+	delete inst;
+}
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
## Summary
- mention 32/64-bit DLLs in README
- add a short docstring to the Python helper
- simplify audio writing in `record_to_wav`

## Testing
- `cmake -B build -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build --target win-capture-audio-wrapper` *(fails: windows headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_686be9c9988c8331ab56f822688e76bf